### PR TITLE
[RocksDB] Add `isClosed` convenience method with tests

### DIFF
--- a/Code/RocksDB.h
+++ b/Code/RocksDB.h
@@ -146,6 +146,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** @brief Closes the database instance */
 - (void)close;
 
+/** @brief Whether or not the database instance is closed */
+- (BOOL)isClosed;
+
 /**
  Sets the default read & write options for all database operations.
 

--- a/Code/RocksDB.mm
+++ b/Code/RocksDB.mm
@@ -178,6 +178,10 @@
 	}
 }
 
+- (BOOL)isClosed {
+    return _db == nullptr;
+}
+
 #pragma mark - Open
 
 - (BOOL)openDatabaseReadOnly:(BOOL)readOnly

--- a/Tests/RocksDBBasicTests.swift
+++ b/Tests/RocksDBBasicTests.swift
@@ -23,6 +23,15 @@ class RocksDBBasicTests : RocksDBTests {
 
 		XCTAssertNil(db)
 	}
+    
+    func testSwift_DB_IsClosed() {
+        rocks = RocksDB.database(atPath: self.path, andDBOptions: { (options) -> Void in
+            options.createIfMissing = true
+        })
+        XCTAssertFalse(rocks.isClosed())
+        rocks.close()
+        XCTAssertTrue(rocks.isClosed())
+    }
 
 	func testSwift_DB_CRUD() {
 		rocks = RocksDB.database(atPath: self.path, andDBOptions: { (options) -> Void in


### PR DESCRIPTION
Fixes #10 

### Changes

- Adds back an `isClosed` convenience method for checking if the database instance has been closed.
  - Includes a test for this scenario.

We use this with `guard` statements to ensure we don't call any db APIs on an already closed database instance.
