### PR TITLE
fix xcode 10 build

### DIFF
--- a/ObjectiveRocks.xcodeproj/project.pbxproj
+++ b/ObjectiveRocks.xcodeproj/project.pbxproj
@@ -3913,9 +3913,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
+			inputFileListPaths = (
+			);
 			inputPaths = (
 			);
 			outputPaths = (
+				"$(SRCROOT)/rocksdb/util/build_version.cc",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3926,9 +3929,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
+			inputFileListPaths = (
+			);
 			inputPaths = (
 			);
 			outputPaths = (
+				"$(SRCROOT)/rocksdb/util/build_version.cc",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
This fixes a build failure with xcode 10 by declaring the build_version.cc file as an output of the run script phase that creates it.  This prevents an error where the file is created too late and the compile step fails because it isn't there in time.
